### PR TITLE
AddRespondersScreen layout

### DIFF
--- a/App.js
+++ b/App.js
@@ -10,6 +10,7 @@ import SnoozeScreen from "./screens/SnoozeScreen";
 import ProfileScreen from "./screens/ProfileScreen";
 import ResourceScreen from "./screens/ResourceScreen";
 import MyRespondersScreen from "./screens/MyRespondersScreen";
+import AddRespondersScreen from "./screens/AddRespondersScreen";
 import DrawerContent from "./components/drawer/DrawerContent";
 import { Provider } from 'react-redux';
 import { createStore, applyMiddleware} from 'redux';
@@ -74,6 +75,10 @@ export default function App() {
               component={MyRespondersScreen}
               title="My Responders"
               initial
+            />
+            <Scene key="add"
+              component={AddRespondersScreen}
+              title="Add Responders"
             />
           </Scene>
         </Scene>

--- a/components/README.md
+++ b/components/README.md
@@ -141,6 +141,62 @@ return(
 );
 ```
 
+**SearchBar**
+
+```
+const [searchBarValue, setSearchBarValue] = useState("");
+
+return (
+  <SearchBar 
+    placeholder="Search for a username"
+    enableClearButton
+    onChangeText={(newText) => setSearchBarValue(newText)}
+    onClearButtonPress={() => setSearchBarValue("")}
+    onSubmitEditing={() => console.log("Searched for", searchBarValue)} 
+  />
+);
+```
+
+Props:
+
+- placeholder: the text shown when the SearchBar is empty
+  - optional
+  - type: string
+- enableClearButton: set to true to enable a clear button that appears on focus
+  - optional
+  - type: boolean
+  - default: true
+- onChangeText: when the text is edited, captures the new value
+  - required
+  - type: func
+- onClearButtonPress: when the clear button is pressed, the search bar text will be cleared. Use this to reset whatever variable you're using to capture the text
+  - optional
+  - type: func
+- onSubmitEditing: callback for when the user enters text then presses the enter key
+  - required
+  - type: func
+
+**Checkbox**
+
+```
+const [checkboxValue, setCheckboxValue] = useState(false);
+
+<Checkbox 
+  checked={checkboxValue}
+  onPress={() => setCheckboxValue(!checkboxValue)} 
+/>
+</Form>
+```
+
+Props:
+
+- checked: true if the checkbox is currently checked
+  - required
+  - type: bool
+- onPress: callback for when the checkbox is pressed
+  - required
+  - type: func
+
 ## Layout
 
 Layout is based on NativeBase's structure.

--- a/components/forms/Checkbox.js
+++ b/components/forms/Checkbox.js
@@ -1,0 +1,44 @@
+import React from "react";
+import PropTypes from "prop-types";
+import theme from "../../styles/base";
+import { Ionicons } from '@expo/vector-icons';
+import { StyleSheet, TouchableOpacity } from "react-native";
+import { CheckBox } from "native-base";
+
+const Checkbox = (props) => {
+  const combinedIconProps = {
+    ...iconProps,
+    name: props.checked? "md-checkbox" : "md-square-outline"
+  }
+
+  return (
+    <TouchableOpacity {...props} onPress={props.onPress} style={[checkboxStyles.checkbox, props.style]}>
+      <Ionicons {...combinedIconProps} />
+    </TouchableOpacity>
+  );
+}
+
+/* Prop Types */
+
+Checkbox.propTypes = {
+  checked: PropTypes.bool.isRequired,
+  onPress: PropTypes.func.isRequired
+}
+
+/* Props */
+
+const iconProps = {
+  color: theme.colors.darkGrey,
+  size: theme.iconSizes.body,
+}
+
+/* Styles */ 
+
+const checkboxStyles = StyleSheet.create({
+  checkbox: {
+    padding: theme.layout.padding,
+    paddingRight: theme.layout.margin
+  }
+});
+
+export default Checkbox;

--- a/components/forms/Input.js
+++ b/components/forms/Input.js
@@ -26,6 +26,8 @@ Input.propTypes = {
   variant: PropTypes.oneOf([ "text", "number"]),
   label: PropTypes.string.isRequired,
   hasNext: PropTypes.bool,
+  onChangeText: PropTypes.func.isRequired,
+  onSubmitEditing: PropTypes.func.isRequired
 };
 
 Input.defaultProps = {

--- a/components/forms/SearchBar.js
+++ b/components/forms/SearchBar.js
@@ -1,0 +1,93 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import theme from "../../styles/base";
+import { Ionicons } from '@expo/vector-icons';
+import { StyleSheet, TouchableOpacity } from "react-native";
+import { Item, Input, Label, Icon } from "native-base";
+
+const SearchBar = (props) => {
+  const [showClearButton, setShowClearButton] = useState(false);
+  let textInput = React.createRef();
+
+  onFocus = () => { setShowClearButton(true); }
+  onBlur = () => { setShowClearButton(false); }
+  
+  const combinedProps = {
+    ...searchBarProps,
+    onFocus: this.onFocus,
+    onBlur: this.onBlur,
+    ...props
+  }
+
+  onClearButtonPress = () => {
+    textInput._root.clear();
+    props.onClearButtonPress();
+
+  }
+
+  return (
+    <Item style={searchBarStyles.item}>
+      <Icon {...iconProps} style={searchBarStyles.icon} />
+      <Input {...combinedProps} style={[searchBarStyles.input, props.style]}
+      ref={(input) => {textInput = input}} />
+        {props.enableClearButton && showClearButton && 
+          <TouchableOpacity onPress={this.onClearButtonPress}>
+            <Icon {...clearButtonProps} style={searchBarStyles.icon} />
+          </TouchableOpacity>
+        }
+    </Item>
+  );
+}
+
+/* Prop Types */
+
+SearchBar.propTypes = {
+  placeholder: PropTypes.string,
+  enableClearButton: PropTypes.bool,
+  onChangeText: PropTypes.func.isRequired,
+  onClearButtonPress: PropTypes.func,
+  onSubmitEditing: PropTypes.func.isRequired
+}
+
+SearchBar.defaultProps = {
+  enableClearButton: false,
+  onClearButtonPress: null
+}
+
+/* Props */
+
+const searchBarProps = {
+  placeholderTextColor: theme.colors.darkGrey,
+}
+
+const iconProps = {
+  name: "md-search",
+}
+
+const clearButtonProps = {
+  name: "md-close-circle"
+}
+
+/* Styles */
+
+const baseStyles = {
+  fontFamily: theme.fonts.body,
+  fontSize: theme.fontSizes.medium,
+  color: theme.colors.darkGrey,
+}
+
+const searchBarStyles = StyleSheet.create({
+  icon: {
+    color: theme.colors.lightGrey,
+    fontSize: theme.iconSizes.body,
+  },
+  item: {
+    ...baseStyles,
+    marginBottom: theme.layout.margin
+  },
+  input: {
+    ...baseStyles,
+  },
+});
+
+export default SearchBar;

--- a/components/layout/Header.js
+++ b/components/layout/Header.js
@@ -15,7 +15,7 @@ const Header = (props) => {
 
   const bodyCombinedStyles = {
     ...headerStyles.body,
-    marginLeft: (props.leftButton)? 16 : 0
+    marginLeft: (props.leftButton)? theme.layout.margin : 0
   }
 
   return (
@@ -47,7 +47,7 @@ const iconName = {
 
 const headerProps = {
   leftButton: {
-    size: 28,
+    size: theme.iconSizes.header,
     color: theme.colors.white,
   }
 };

--- a/screens/AddRespondersScreen.js
+++ b/screens/AddRespondersScreen.js
@@ -1,0 +1,146 @@
+import React, { Component } from "react";
+import { StyleSheet } from "react-native";
+import { Actions } from "react-native-router-flux";
+import { Container, Content, Header, View, List, ListItem } from "../components/layout";
+import { Checkbox, SearchBar, Input } from "../components/forms";
+import { Text } from "../components/typography";
+import { Button } from "../components/buttons";
+import theme from "../styles/base";
+
+// fake data
+const fakeResponders = [
+  "a",
+  "aa",
+  "ab",
+  "b",
+  "ba",
+  "bb",
+  "bc",
+  "c",
+  "ca",
+  "cb",
+  "cc",
+];
+
+class AddRespondersScreen extends Component {
+  constructor(props) {
+    super(props);
+    // TODO: fetch all responders (& put in alphabetical order)
+    let responderSelectionMap = new Map();
+    for (username of fakeResponders) {
+      responderSelectionMap.set(username, false);
+    }
+    this.state = {
+      searchQuery: "",
+      responderSelectionMap: responderSelectionMap,
+      allResponders: fakeResponders,
+      queriedResponders: fakeResponders
+    };
+  }
+
+  onCheckboxPress = (username) => {
+    let responderSelectionMap = this.state.responderSelectionMap;
+    let oldValue = responderSelectionMap.get(username);
+    responderSelectionMap.set(username, !oldValue);
+    this.setState({responderSelectionMap});
+  }
+
+  regexEscape = (str) => {
+    return str.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&");
+  }
+
+  searchForUsername = () => {
+    const searchQuery = this.regexEscape(this.state.searchQuery);
+    const regex = new RegExp("^" + searchQuery, "i");
+    let queriedResponders = [];
+    for (username of this.state.allResponders) {
+      if (regex.test(username)) {
+        queriedResponders.push(username);
+      }
+    }
+    this.setState({queriedResponders});
+  }
+
+  addSelectedResponders = () => {
+    let selectedResponders = [];
+    for (let [username, isSelected] of this.state.responderSelectionMap) {
+      if (isSelected) {
+        selectedResponders.push(username);
+      }
+    }
+    // TODO: ping backend to add the usernames in selectedResponders as responders for this user
+    
+    Actions.pop();
+  }
+
+  render() {
+    return (
+      <Container>
+        <Header leftButton="arrow" 
+        onLeftButtonPress={() => Actions.pop()}
+        >
+          Add Responders
+        </Header>
+
+        <Content>
+          <View style={styles.search}>
+            <SearchBar placeholder="Search for a username"
+              enableClearButton
+              onChangeText={(searchQuery) => this.setState({searchQuery})}
+              onClearButtonPress={() => this.setState({searchQuery: ""})}
+              onSubmitEditing={() => this.searchForUsername()} 
+            />
+          </View>
+
+          <List style={styles.list}>
+            {
+              (this.state.queriedResponders.length == 0) ?
+              
+                <Text>No results found.</Text>
+              
+              :
+              
+                this.state.queriedResponders.map((username, index) => {
+                  return (
+                    <View style={styles.row} key={index}>
+                      <Checkbox checked={this.state.responderSelectionMap.get(username)}
+                        onPress={() => this.onCheckboxPress(username)} />
+                      <ListItem
+                        leftText={username}
+                      />
+                    </View>
+                  );
+                })
+              
+            }
+          </List>
+
+          <View style={styles.addButton}>
+            <Button variant="primary" style={{backgroundColor: theme.colors.green}}
+            onPress={() => this.addSelectedResponders()}>add selected</Button>
+          </View>
+        </Content>
+      </Container>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  search: {
+    flex: 0,
+  },
+  list: {
+  },
+  row: {
+    flexDirection: "row",
+    justifyContent: "space-around"
+  },
+  addButton: {
+    flex: 0,
+    flexDirection: "row",
+    justifyContent: "space-around",
+    marginTop: theme.layout.margin
+  }
+});
+
+export default AddRespondersScreen;

--- a/screens/LoginScreen.js
+++ b/screens/LoginScreen.js
@@ -76,6 +76,7 @@ class LoginScreen extends Component {
                   this.setState({ password: password });
                   console.log(this.state.password);
                 }}
+                onSubmitEditing={() => Actions.signup()}
               />
             </View>
 

--- a/screens/MyRespondersScreen.js
+++ b/screens/MyRespondersScreen.js
@@ -72,7 +72,7 @@ class MyRespondersScreen extends Component {
 
           <View style={styles.buttons}>
             <Button variant="primary">remove</Button>
-            <Button variant="primary">add</Button>
+            <Button variant="primary" onPress={() => Actions.add()}>add</Button>
           </View>
         </Content>
       </Container>

--- a/styles/base.js
+++ b/styles/base.js
@@ -20,6 +20,10 @@ export const theme = {
     large: 24,
     xlarge: 72,
   },
+  iconSizes: {
+    header: 28,
+    body: 24,
+  },
   layout: {
     padding: 4,
     margin: 16,


### PR DESCRIPTION
- Added AddRespondersScreen to navigation and set up screen layout
- Created new components: Checkbox and SearchBar
- The user can check/uncheck usernames
- The search bar filters usernames using a regex (looks for an exact match at the beginning of the word, ignores case) which we can change later if desired
- Hitting the "add selected" button will produce an array with all the usernames that have been checked, whether they are currently on-screen or not
- I took out the "search" button shown on Figma because I felt like it took up too much space on the screen compared to the list of usernames, but we can add it easily
- The only possible bug: on an Android device, does the search bar show text to be underlined ? It did on my emulator (see screenshot).
![UHN-MA-26_ios_search](https://user-images.githubusercontent.com/42985875/72661578-881e9180-3990-11ea-89d1-2bad2f8056f8.jpg)
![UHN-MA-26_android_add](https://user-images.githubusercontent.com/42985875/72661579-881e9180-3990-11ea-93a0-6a4f98ae8d12.jpg)
![UHN-MA-26_android_search](https://user-images.githubusercontent.com/42985875/72661580-88b72800-3990-11ea-92ea-04d46ff91a1f.jpg)
![UHN-MA-26_ios_add](https://user-images.githubusercontent.com/42985875/72661581-88b72800-3990-11ea-8a58-2163b05d8236.jpg)
